### PR TITLE
Added LCParser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,12 @@
             <artifactId>mysql-connector-j</artifactId>
             <version>9.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
          <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/edu/regis/merc/err/EtxException.java
+++ b/src/main/java/edu/regis/merc/err/EtxException.java
@@ -1,0 +1,29 @@
+/*
+ * MERC^T: Multiple External Representations of Computation Tutor
+ * 
+ *  (C) Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.merc.err;
+
+/**
+ * Thrown when a parser encounters the input expression (End of Text).
+ * 
+ * @author rickb
+ */
+public class EtxException extends MercException {
+    /**
+     * Initialize this exception with the given message.
+     * 
+     * @param msg a description of the error that occurred
+     */
+    public EtxException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/edu/regis/merc/err/LCParseException.java
+++ b/src/main/java/edu/regis/merc/err/LCParseException.java
@@ -1,0 +1,42 @@
+/*
+ * MERC^T: Multiple External Representations of Computation Tutor
+ * 
+ *  (C) Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.merc.err;
+
+/**
+ * Thrown when the Lambda Calculus parser encounters illegal syntax.
+ * 
+ * See the message and if the wrapped cause is not null, it is an EtxException 
+ * (indicating the end of the expression was reached before parsing finished).
+ * 
+ * @author rickb
+ */
+public class LCParseException extends MercException {
+    /**
+     * Initialize this exception with the given message.
+     * 
+     * @param msg a description of the error that occurred
+     */
+    public LCParseException(String msg) {
+        super(msg);
+    }
+    
+    /**
+     * Initialize this exception with the given message.
+     * 
+     * @param msg
+     * @param cause Presumable an ExtException
+     */
+    public LCParseException(String msg, Throwable cause) {
+	super(msg, cause);
+    }
+}

--- a/src/main/java/edu/regis/merc/model/LCAbstraction.java
+++ b/src/main/java/edu/regis/merc/model/LCAbstraction.java
@@ -15,26 +15,51 @@ package edu.regis.merc.model;
 import java.util.ArrayList;
 
 /**
+ * An Lambda Calculus Abstraction (function) with identified parameter(s) and body.
  * 
  * @author ellis
+ * @author rickb
  */
-public class LCAbstraction {
+public class LCAbstraction extends LCExpression {
+    /**
+     * If true, this Abstraction allows Curried parameters.
+     */
+    private boolean isCurried = false;
     
-    private ArrayList<String> parameters;
+    /**
+     * The parameters in this Abstraction as a list of Lambda Calculus variables.
+     */
+    private ArrayList<LCVariable> parameters;
+    
+    /**
+     * The body of this Abstraction as a list of Lambda Calculus expressions.
+     */
     private ArrayList<LCExpression> body;
     
+    /**
+     * Initialize this Lambda Calculus Abstraction with an empty parameter list
+     * and an empty body.
+     */
     public LCAbstraction(){
-        this.parameters = new ArrayList<String>();
-        this.body = new ArrayList<LCExpression>();
+        this.parameters = new ArrayList<>();
+        this.body = new ArrayList<>();
         
     }
     
-    public void setParameters(ArrayList<String> parameters){
+    public void addParameter(LCVariable parameter) {
+        parameters.add(parameter);
+    }
+    
+    public void setParameters(ArrayList<LCVariable> parameters){
         this.parameters = parameters;
     }
     
-    public ArrayList<String> getParameters(){
+    public ArrayList<LCVariable> getParameters(){
         return parameters;
+    }
+    
+    public void addBodyPart(LCExpression expression) {
+        body.add(expression);
     }
     
     public void setBody(ArrayList<LCExpression> body){
@@ -43,6 +68,42 @@ public class LCAbstraction {
     
     public ArrayList<LCExpression> getBody(){
         return body;
+    }
+
+    public boolean isIsCurried() {
+        return isCurried;
+    }
+
+    public void setIsCurried(boolean isCurried) {
+        this.isCurried = isCurried;
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder buff = new StringBuilder();
+        
+        if (isParentheses) {
+            buff.append("(");
+        }
+        
+        buff.append("\\");
+        
+        for (LCVariable parameter : parameters) {
+            buff.append(parameter);
+        }
+        
+        buff.append(".");
+        
+        for (LCExpression expr : body) {
+            buff.append(" ");
+            buff.append(expr.toString());
+        }
+        
+        if (isParentheses) {
+            buff.append(")");
+        }
+        
+        return buff.toString();
     }
 }  
    

--- a/src/main/java/edu/regis/merc/model/LCApplication.java
+++ b/src/main/java/edu/regis/merc/model/LCApplication.java
@@ -13,12 +13,22 @@
 package edu.regis.merc.model;
 
 /**
- *
+ * A Lambda Calculus Application (function call) with an identified Abstraction
+ * and argument.
+ * 
  * @author ellis
+ * @author rickb
  */
-public class LCApplication {
-    
+public class LCApplication extends LCExpression {
+    /**
+     * The Lambda Calculus Abstraction that is applied to the argument in this
+     * Application.
+     */
     private LCAbstraction function;
+    
+    /**
+     * The argument for this Application.
+     */
     private LCExpression arg;
     
     public LCApplication(){
@@ -40,5 +50,16 @@ public class LCApplication {
     
     public LCExpression getArg(){
         return arg;
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder buff = new StringBuilder();
+        
+        buff.append(function.toString());
+        buff.append(" ");
+        buff.append(arg.toString());
+        
+        return buff.toString();
     }
 }

--- a/src/main/java/edu/regis/merc/model/LCExpression.java
+++ b/src/main/java/edu/regis/merc/model/LCExpression.java
@@ -18,8 +18,8 @@ package edu.regis.merc.model;
  */
 public class LCExpression {
 
-    private boolean isParentheses;
-    private boolean isApplied;
+    protected boolean isParentheses;
+    protected boolean isApplied;
     
     public LCExpression() {
         isParentheses = false;

--- a/src/main/java/edu/regis/merc/model/LCParser.java
+++ b/src/main/java/edu/regis/merc/model/LCParser.java
@@ -1,0 +1,405 @@
+/*
+ * MERC^T: Multiple External Representations of Computation Tutor
+ * 
+ *  (C) Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.merc.model;
+
+import edu.regis.merc.err.EtxException;
+import edu.regis.merc.err.LCParseException;
+
+/**
+ * A utility for parsing a Lambda Calculus string into its constituent objects.
+ *
+ * Note: Lambdas are represented ala Haskell with a '\', which in a Java String
+ * must be escaped, hence, "(\\x. x)"
+ *
+ * Tested on: "\\x. x" Simple Abstractions "(\\x. x)" "(\\x . x)" "(\\x. f x)"
+ * "(\\f. (\\x. x))" Church Numeral Zero "(\\f. (\\x. f x))" Church Numeral One
+ * "(\\x. x) x Simple Applications "(\\x. x) (x)" "(\\n. (\\f. (\\x. x))) Zero
+ * Function "(\\n. (\\f. (\\x. x))) (\\f. (\\x. f x))" Zero Function applied to
+ * 1
+ *
+ * @author rickb
+ */
+public class LCParser {
+    /**
+     * The singleton instance of this class.
+     */
+    private final static LCParser SINGLETON;
+
+    /**
+     * ASCII End of Text (indicates the end of the input text to parse).
+     */
+    private final static char ETX = '\3';
+
+    // Invoked when this class is loaded
+    static {
+        SINGLETON = new LCParser();
+    }
+
+    /**
+     * Return the singleton instance of this frame.
+     *
+     * @return the LCParser singleton
+     */
+    public static LCParser instance() {
+        return SINGLETON;
+    }
+
+    /**
+     * The Lambda Calculus expression currently being parsed.
+     */
+    private String expression;
+
+    /**
+     * If true, an applied calculus is allowed in the expression syntax.
+     */
+    private boolean isApplied;
+
+    /**
+     * If true, currying of parameters is allowed in the expression syntax for
+     * abstractions.
+     */
+    private boolean isCurried;
+
+    /**
+     * The current character being parsed in the input expression.
+     */
+    private int pos;
+
+    /**
+     * Parse the given Lambda Calculus expression.
+     *
+     * @param expression the Lambda Calculus Expression to parse, such as "(\\x.
+     * x) x"
+     * @param isApplied true, if variables can be more than one character
+     * @param isCurried true, if abstractions can have multiple parameters
+     * separated by commas
+     * @return an LCExpression
+     * @throws LCParseException see the message and if the wrapped cause is not
+     * null, it is an EtxException (indicating the end of the expression was
+     * reached before parsing finished).
+     */
+    public LCExpression parse(String expression, boolean isApplied, boolean isCurried) throws LCParseException {
+        this.expression = expression;
+        this.isApplied = isApplied;
+        this.isCurried = isCurried;
+
+        if (expression == null) {
+            throw new LCParseException("Expression cannot be null");
+
+        } else if (expression.length() == 0) {
+            throw new LCParseException("Expression cannot be an empty string");
+
+        } else {
+            pos = -1;
+
+            return parseLCExpression();
+        }
+    }
+
+    /**
+     * Given the current position (pos) in the input expression, we're expecting
+     * another Lambda Calculus expression.
+     *
+     * @return an LCExpression
+     * @throws LCParseException see the note on the parse() method exception.
+     */
+    private LCExpression parseLCExpression() throws LCParseException {
+        char ch;
+
+        try {
+            ch = nextChar();
+        } catch (EtxException e) {
+            throw new LCParseException("ETX reached before reading anything", e);
+        }
+
+        switch (ch) {
+            case '\\':  // a Lambda ala Haskell beginning an Abstraction
+                LCAbstraction abstraction = parseAbstraction();
+
+                return abstraction;
+
+            case '(':
+                LCExpression expr = parseLCExpression();
+
+                try {
+                    ch = nextChar();
+                } catch (EtxException e) {
+                    throw new LCParseException("Etx encountered when expecting a ')'", e);
+                }
+
+                matchChar(ch, ')');
+
+                expr.setIsParentheses(true);
+
+                if (expr instanceof LCAbstraction) {
+                    return parsePossibleApplication((LCAbstraction) expr);
+                } else {
+                    return expr;
+                }
+
+            default:
+                if (Character.isAlphabetic(ch)) {
+                    return parseVariable();
+                } else {
+                    throw new LCParseException("Expecting a variable");
+                }
+        }
+    }
+
+    /**
+     * As a Lambda '\\' was read and is at the current position, begin parsing 
+     * the remainder of the Abstraction returning it as an LCAbstraction.
+     * 
+     * @return an LCAbstraction
+     * @throws LCParseException see the note on the parse() method exception.
+     */
+    private LCAbstraction parseAbstraction() throws LCParseException {
+        LCAbstraction abstraction = new LCAbstraction();
+
+        parseAbstractionParameters(abstraction);
+
+        try {
+            char ch = nextChar();
+
+            matchChar(ch, '.');
+
+            parseAbstractionBody(abstraction);
+
+            return abstraction;
+
+        } catch (EtxException e) {
+            throw new LCParseException("Etx occurred when expecting '.' in abstraciton body.");
+        }
+
+    }
+
+    /**
+     * As a Lambda '\\' was read and is at the current position, begin parsing 
+     * the parameters in the Abstraction adding them to the given LCAbstraction.
+     * 
+     * There must be at least one parameter to read, otherwise a parse exception.
+     * 
+     * @param abstraction the LCAbstraction that is being parsed.
+     * @throws LCParseException see the note on the parse() method exception.
+     */
+    public void parseAbstractionParameters(LCAbstraction abstraction) throws LCParseException {
+        boolean moreParameters = true;
+
+        try {
+            // We're currently parsing the '\\', so move past it to the first
+            // character of the first parameter. 
+            char ch = nextChar();
+
+            do {
+                parseParameter(abstraction);
+
+                ch = nextChar();
+
+                if (isCurried && (ch == ',')) {
+                    abstraction.setIsCurried(true);
+                    nextChar();
+
+                } else {
+                    pos--; // Peeked one char too far, push it back.
+                    moreParameters = false;
+                }
+
+            } while (moreParameters); // if true get the next curried parameter
+
+        } catch (EtxException e) {
+            throw new LCParseException("Etx encountered while looking for abstraction parameter", e);
+        }
+    }
+
+    /**
+     * Assumed that we're sitting at the first letter of a variable token,
+     * parse it and add it to the given LCAbstraction
+     * 
+     * @param abstraction the LCAbstraction whose parameter is being parsed.
+     * @throws LCParseException see the note on the parse() method exception.
+     */
+    private void parseParameter(LCAbstraction abstraction) throws LCParseException {
+        abstraction.addParameter(parseVariable());
+    }
+
+    /**
+     * As a '.' was read and is at the current position, begin parsing the
+     * Abstraction's body adding it to the given LCAbstraction.
+     * 
+     * @param abstraction
+     * @throws LCParseException see the note on the parse() method exception.
+     */
+    private void parseAbstractionBody(LCAbstraction abstraction) throws LCParseException {
+        boolean readingBodyParts = true;
+
+        char ch;
+
+        try {
+            ch = nextChar(); // There needs to be something
+            pos--; // Peeked too far, push it back.
+
+        } catch (EtxException e) {
+            throw new LCParseException("Etx encountered when expecting abstraction body", e);
+        }
+
+        do {
+            LCExpression bodyPart = parseLCExpression();
+            
+            abstraction.addBodyPart(bodyPart);
+
+            try {
+                ch = nextChar();
+
+                if (ch == ')') // A body part cannot begin with a ')'
+                    readingBodyParts = false;
+
+                pos--; // We peeked one char too far, push it back.
+
+            } catch (EtxException e) {
+                readingBodyParts = false;
+            }
+
+        } while (readingBodyParts);
+    }
+
+    /**
+     * As we've just parsed an Abstraction, it's possible that it's followed by
+     * arguments, in which case they are parsed and an LCApplication is returned,
+     * otherwise, return the given LCAbstraction.
+     * 
+     * @param abstraction a recently parsed LCAbstraction.
+     * @return either the given LCAbstraction or an LCApplication with the
+     *         given LCAbstraction as its function.
+     * @throws LCParseException see the note on the parse() method exception.
+     */
+    private LCExpression parsePossibleApplication(LCAbstraction abstraction) throws LCParseException {
+        char ch;
+
+        try {
+            ch = nextChar(); // Looking for anything vs. ETX
+
+            if (ch == ')') { // Cannot be the start of an application
+                pos--;
+                return abstraction; // return the abstraction   
+            }
+
+            // Peeked one too far, push it back, should be the start
+            // of the args in an application
+            pos--;
+
+        } catch (EtxException e) { // this is okay, it's not an application
+            return abstraction;           // return the abstraction
+        }
+
+        LCExpression arg = parseLCExpression();
+
+        LCApplication application = new LCApplication();
+        application.setFunction(abstraction);
+        application.setArg(arg);
+
+        return application;
+    }
+
+    /**
+     * Beginning at the current position (pos), parse a Variable, it's expected
+     * that the current position corresponds to the first character in the
+     * variable.
+     * 
+     * @return an LCVariable
+     * @throws LCParseException see the note on the parse() method exception.
+     */
+    private LCVariable parseVariable() throws LCParseException {
+        return new LCVariable(parseToken());
+    }
+
+    /**
+     * If the given received character doesn't match the expected character,
+     * throw a parsing exception
+     * 
+     * @param received the char that was just read in the expression input.
+     * @param expected the char that was expected.
+     * @throws LCParseException see the note on the parse() method exception.
+     */
+    private void matchChar(char received, char expected) throws LCParseException {
+        if (received != expected) {
+            String msg = "Expecting '" + expected + "but received " + received + " at position " + pos;
+            throw new LCParseException(msg);
+        }
+    }
+
+    /**
+     * Return the alphabetic token beginning at the current parse position (pos).
+     *
+     * It is assumed pos is at the first alphabetic character of a token.
+     *
+     * @return
+     * @throws LCParseException
+     */
+    private String parseToken() throws LCParseException {
+        StringBuilder buff = new StringBuilder();
+
+        char ch = expression.charAt(pos);
+
+        if (Character.isAlphabetic(ch)) {
+            buff.append(ch);
+        } else {
+            throw new LCParseException("Initial char of token '" + ch + "' at pos " + pos + " should be alphabet in parseToken");
+        }
+
+        // For an applied calculus look for the remainder of a variable name.
+        if (isApplied) {
+            boolean isAppliedToken = true;
+                    
+            do {
+                try {
+                    ch = nextChar();
+
+                    if (Character.isAlphabetic(ch)) {
+                        buff.append(ch);
+                    } else {
+                        pos--; // we read one character too far, push it back.
+                        isAppliedToken = false;
+                    }
+                } catch (EtxException e) {  // This is okay token ended at ETX
+                    isAppliedToken = false;
+                }
+
+            } while (isAppliedToken);
+        }
+
+        return buff.toString();
+    }
+
+    /**
+     * Increment to the next position in the expression and return the next
+     * non white space char.
+     * 
+     * @return a non white space char
+     * @throws EtxException the end of the expression was reached, which isn't
+     *                      necessarily an error depending on where we are in
+     *                      the parsing rules.
+     */
+    private char nextChar() throws EtxException {
+        char ch;
+
+        do {
+            if (++pos == expression.length())
+                throw new EtxException("Etx reached");
+
+            ch = expression.charAt(pos);
+
+        } while (Character.isWhitespace(ch));
+
+        return ch;
+    }
+}

--- a/src/main/java/edu/regis/merc/model/LCVariable.java
+++ b/src/main/java/edu/regis/merc/model/LCVariable.java
@@ -13,15 +13,24 @@
 package edu.regis.merc.model;
 
 /**
- *
+ * A Lambda Calculus variable (token) with a given name.
+ * 
  * @author ellis
+ * @author rickb
  */
-public class LCVariable {
-    
+public class LCVariable extends LCExpression {
+    /**
+     * The symbolic name of this variable. 
+     */
     private String name;
     
-    public LCVariable(){
-        name = null;
+    /**
+     * Initialize this Lambda Calculus variable with the given symbolic name.
+     * 
+     * @param name an alphabetic name
+     */
+    public LCVariable(String name){
+        this.name = name;
     }
     
     public void setName(String name){
@@ -29,6 +38,11 @@ public class LCVariable {
     }
     
     public String getName(){
+        return name;
+    }
+    
+    @Override
+    public String toString() {
         return name;
     }
 }

--- a/src/test/java/edu/regis/merc/test/TestLCParser.java
+++ b/src/test/java/edu/regis/merc/test/TestLCParser.java
@@ -1,0 +1,100 @@
+/*
+ * MERC^T: Multiple External Representations of Computation Tutor
+ * 
+ *  (C) Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.merc.test;
+
+import edu.regis.merc.model.LCExpression;
+import edu.regis.merc.model.LCParser;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A unit test for the LCParser.
+ * 
+ * @author rickb
+ */
+public class TestLCParser {
+    /**
+     * Convenience reference to the Lambda Calculus parser.
+     */
+    private static LCParser parser;
+
+    /**
+     * Initialize the GSON_INS and TUTOR_INS instances.
+     */
+    @BeforeAll
+    public static void setUpClass() {
+        //System.out.println("BeforeAll setUpClass");
+        parser = new LCParser();
+    }
+
+    /**
+     * Unit test for the Lambda Calculus Parser.
+     */
+    @Test
+    public void testParser() {
+        assertNotNull(parser);
+
+        
+        // String churchOne = "(\\x. f x)"; // ALso tested with no parens \\x. x
+       // LCExpression t5Expr = Assertions.assertDoesNotThrow(() -> parser.parse(churchOne, false, false),
+        //        "Parse test1 abstration should not throw an exception");
+        
+        //System.out.println("one: " + t5Expr.toString());
+        
+
+        String testStr1 = "(\\x. x)"; // ALso tested with no parens \\x. x
+
+        LCExpression t1Expr = Assertions.assertDoesNotThrow(() -> parser.parse(testStr1, false, false),
+                "Parse test1 abstration should not throw an exception");
+
+        
+        assertEquals("(\\x. x)", t1Expr.toString());
+
+        // ****************************
+        String t2Expr = "(\\x. x) x"; // Also tested with (\\x. x) (x)
+
+        LCExpression expr2 = Assertions.assertDoesNotThrow(() -> parser.parse(t2Expr, false, false),
+                "Parse test 2 application should not throw an exception");
+
+        assertEquals("(\\x. x) x", t2Expr.toString());
+
+        // ********************************
+        String churchZero = "(\\f. (\\x. x))";
+
+        LCExpression expr3 = Assertions.assertDoesNotThrow(() -> parser.parse(churchZero, false, false),
+                "Parse church zero should not throw an exception");
+
+        assertEquals("(\\f. (\\x. x))", expr3.toString());
+
+        // ***********************
+        String zeroFunction = "(\\n. (\\f. (\\x. x)))";
+
+        LCExpression expr4 = Assertions.assertDoesNotThrow(() -> parser.parse(zeroFunction, false, false),
+                "Parse zero function should not throw an exception");
+
+        assertEquals("(\\n. (\\f. (\\x. x)))", expr4.toString());
+
+        // ***********************
+        String zeroFunctionApp = "(\\n. (\\f. (\\x. x))) (\\f. (\\x. f x))";
+
+        LCExpression expr5 = Assertions.assertDoesNotThrow(() -> parser.parse(zeroFunctionApp, false, false),
+                "Parse zero function should not throw an exception");
+        
+        assertEquals("(\\n. (\\f. (\\x. x))) (\\f. (\\x. f x))", expr5.toString());
+
+    }
+}


### PR DESCRIPTION
Added LCParser with minor updates to the LC model classes. Also added a unit test TestLCParser.
Pom.xml file update for org.junit.jupiter

Verified that the following inputs parse correctly:
 "\\x. x"                                  Simple Abstractions
 "(\\x. x)" 
"(\\x . x)" 
"(\\x. f x)"
 * "(\\f. (\\x. x))"                    Church Numeral Zero 
 * "(\\f. (\\x. f x))"                  Church Numeral One
 * "(\\x. x) x                           Simple Applications 
 * "(\\x. x) (x)" 
 * "(\\n. (\\f. (\\x. x)))"           Zero Function 
 * "(\\n. (\\f. (\\x. x))) (\\f. (\\x. f x))" Zero Function applied to Church Numeral One